### PR TITLE
Add definitionProvider for ctrl+click support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { StepMapping, getStepFileStepForFeatureFileStep, getStepMappingsForSteps
 import { autoCompleteProvider } from './handlers/autoCompleteProvider';
 import { formatFeatureProvider } from './handlers/formatFeatureProvider';
 import { SemHighlightProvider, semLegend } from './handlers/semHighlightProvider';
+import { DefinitionProvider } from './handlers/definitionProvider';
 import { startWatchingWorkspace } from './watchers/workspaceWatcher';
 import { JunitWatcher } from './watchers/junitWatcher';
 
@@ -86,7 +87,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<TestSu
       vscode.commands.registerCommand(`behave-vsc.stepReferences.next`, nextStepReferenceHandler),
       vscode.languages.registerCompletionItemProvider('gherkin', autoCompleteProvider, ...[" "]),
       vscode.languages.registerDocumentRangeFormattingEditProvider('gherkin', formatFeatureProvider),
-      vscode.languages.registerDocumentSemanticTokensProvider({ language: 'gherkin' }, new SemHighlightProvider(), semLegend)
+      vscode.languages.registerDocumentSemanticTokensProvider({ language: 'gherkin' }, new SemHighlightProvider(), semLegend),
+      vscode.languages.registerDefinitionProvider({ language: 'gherkin' }, new DefinitionProvider())
     );
 
 

--- a/src/handlers/definitionProvider.ts
+++ b/src/handlers/definitionProvider.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+import { config } from "../configuration";
+import { getWorkspaceUriForFile, isFeatureFile } from "../common";
+import { getStepFileStepForFeatureFileStep, waitOnReadyForStepsNavigation } from "../parsers/stepMappings";
+import { featureFileStepRe } from "../parsers/featureParser";
+
+
+export class DefinitionProvider implements vscode.DefinitionProvider {
+  async provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Location | vscode.LocationLink[] | undefined> {
+    const docUri = document.uri;
+
+    try {
+      if (!docUri || !isFeatureFile(docUri)) {
+        return undefined;
+      }
+
+      const lineNo = position.line;
+      const lineText = document.lineAt(lineNo).text.trim();
+      const stExec = featureFileStepRe.exec(lineText);
+      if (!stExec) {
+        return undefined;
+      }
+
+      if (!await waitOnReadyForStepsNavigation(500, docUri)) {
+        return undefined;
+      }
+
+      const stepFileStep = getStepFileStepForFeatureFileStep(docUri, lineNo);
+
+      if (!stepFileStep) {
+        return undefined;
+      }
+
+      // Find the start of the step text (after the Given/When/Then/And/But keyword)
+      const line = document.lineAt(lineNo);
+      const trimmedStart = line.text.indexOf(lineText);
+      const originRange = new vscode.Range(
+        new vscode.Position(lineNo, trimmedStart),
+        new vscode.Position(lineNo, line.text.length)
+      );
+
+      // Return a LocationLink with originSelectionRange to control the underlined span
+      return [{
+        originSelectionRange: originRange,
+        targetUri: stepFileStep.uri,
+        targetRange: stepFileStep.functionDefinitionRange,
+        targetSelectionRange: stepFileStep.functionDefinitionRange
+      }];
+    }
+    catch (e: unknown) {
+      try {
+        const wkspUri = getWorkspaceUriForFile(docUri);
+        config.logger.showError(e, wkspUri);
+      }
+      catch {
+        config.logger.showError(e);
+      }
+      return undefined;
+    }
+  }
+}


### PR DESCRIPTION
**Issue #66**

**Description of changes**
I added a DefinitionProvider that allows you to ctrl + left-click to jump from feature files to underlying step definitions

**Testing**
I tested in the simple example project on Windows Subsystem for Linux Ubuntu.

By submitting this pull request, I confirm that my contribution is made under the terms of the parent repository's license, and requires no attribution or license modification.
