### PR TITLE
Use Diagnostics for Duplicate scenarios

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,6 +8,7 @@ export interface Configuration {
   integrationTestRun: boolean;
   readonly extensionTempFilesUri: vscode.Uri;
   readonly logger: Logger;
+  readonly diagnostics: vscode.DiagnosticCollection;
   readonly workspaceSettings: { [wkspUriPath: string]: WorkspaceSettings };
   readonly globalSettings: WindowSettings;
   reloadSettings(wkspUri: vscode.Uri, testConfig?: vscode.WorkspaceConfiguration): void;
@@ -22,6 +23,7 @@ class ExtensionConfiguration implements Configuration {
   public exampleProject = false;
   public readonly extensionTempFilesUri;
   public readonly logger: Logger;
+  public readonly diagnostics: vscode.DiagnosticCollection;
   private static _configuration?: ExtensionConfiguration;
   private _windowSettings: WindowSettings | undefined = undefined;
   private _resourceSettings: { [wkspUriPath: string]: WorkspaceSettings } = {};
@@ -29,6 +31,7 @@ class ExtensionConfiguration implements Configuration {
   private constructor() {
     ExtensionConfiguration._configuration = this;
     this.logger = new Logger();
+    this.diagnostics = vscode.languages.createDiagnosticCollection("behave-vsc");
     this.extensionTempFilesUri = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), "behave-vsc");
     this.exampleProject = (vscode.workspace.workspaceFolders?.find(f =>
       f.uri.path.includes("/behave-vsc/example-projects/")) !== undefined);
@@ -37,6 +40,7 @@ class ExtensionConfiguration implements Configuration {
 
   public dispose() {
     this.logger.dispose();
+    this.diagnostics.dispose();
   }
 
   static get configuration() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<TestSu
       ctrl,
       treeView,
       config,
+      config.diagnostics,
       cleanExtensionTempDirectoryCancelSource,
       junitWatcher,
       vscode.commands.registerTextEditorCommand(`behave-vsc.gotoStep`, gotoStepHandler),

--- a/src/parsers/featureParser.ts
+++ b/src/parsers/featureParser.ts
@@ -113,7 +113,7 @@ export const parseFeatureContent = (wkspSettings: WorkspaceSettings, uri: vscode
     if (scenario) {
       const scenarioName = scenario[2].trim();
       const isOutline = scenarioOutlineRe.exec(line) !== null;
-      const range = new vscode.Range(new vscode.Position(lineNo, 0), new vscode.Position(lineNo, scenario[0].length));
+      const range = new vscode.Range(new vscode.Position(lineNo, indentSize), new vscode.Position(lineNo, indentSize + scenario[0].length));
       onScenarioLine(range, scenarioName, isOutline);
       fileScenarios++;
       continue;

--- a/src/parsers/testFile.ts
+++ b/src/parsers/testFile.ts
@@ -13,6 +13,29 @@ export type TestData = WeakMap<vscode.TestItem, BehaveTestData>;
 export class TestFile {
   public didResolve = false;
 
+  private addDuplicateScenarioDiagnostics(featureUri: vscode.Uri, scenarioRanges: Map<string, vscode.Range[]>) {
+    const existingDiagnostics = config.diagnostics.get(featureUri) || [];
+    const newDiagnostics = [...existingDiagnostics];
+
+    for (const [scenarioName, ranges] of scenarioRanges) {
+      if (ranges.length > 1) {
+        diagLog(`Duplicate scenario detected: "${scenarioName}"`);
+
+        for (const range of ranges) {
+          const diagnostic = new vscode.Diagnostic(
+            range,
+            `Duplicate scenario name: "${scenarioName}". Each scenario in a feature file must have a unique name.`,
+            vscode.DiagnosticSeverity.Error
+          );
+          diagnostic.code = "duplicate-scenario";
+          diagnostic.source = "behave-vsc";
+          newDiagnostics.push(diagnostic);
+        }
+      }
+    }
+    config.diagnostics.set(featureUri, newDiagnostics);
+  }
+
   public async createScenarioTestItemsFromFeatureFileContent(wkspSettings: WorkspaceSettings, content: string, testData: TestData,
     controller: vscode.TestController, item: vscode.TestItem, caller: string) {
     if (!item.uri)
@@ -31,7 +54,13 @@ export class TestFile {
 
     const thisGeneration = generationCounter++;
     const ancestors: { item: vscode.TestItem, children: vscode.TestItem[] }[] = [];
+    const scenarioRanges = new Map<string, vscode.Range[]>();
     this.didResolve = true;
+
+    // Clear any existing diagnostics for this file
+    const existingDiagnostics = config.diagnostics.get(featureUri) || [];
+    const nonDuplicateDiagnostics = existingDiagnostics.filter(d => d.code !== "duplicate-scenario");
+    config.diagnostics.set(featureUri, nonDuplicateDiagnostics);
 
     const ascend = (depth: number) => {
       while (ancestors.length > depth) {
@@ -42,13 +71,9 @@ export class TestFile {
           finished.item.children.replace(finished.children);
         }
         catch (e: unknown) {
-          let err = (e as Error).toString();
+          const err = (e as Error).toString();
           if (err.includes("duplicate test item")) {
-            const n = err.lastIndexOf('/');
-            const scen = err.substring(n);
-            err = err.replace(scen, `. Duplicate scenario name: "${scen.slice(1)}".`);
-            // don't throw here, show it and carry on
-            config.logger.showError(err, wkspSettings.uri);
+            this.addDuplicateScenarioDiagnostics(featureUri, scenarioRanges);
           }
           else
             throw e;
@@ -58,6 +83,11 @@ export class TestFile {
 
     const onScenarioLine = (range: vscode.Range, scenarioName: string, isOutline: boolean) => {
       const parent = ancestors[ancestors.length - 1];
+
+      // Track scenario name and range for duplicate detection
+      const ranges = scenarioRanges.get(scenarioName) || [];
+      ranges.push(range);
+      scenarioRanges.set(scenarioName, ranges);
 
       const data = new Scenario(featureFilename, featureFileWkspRelativePath, featureName, scenarioName, thisGeneration, isOutline);
       const id = `${uriId(featureUri)}/${data.getLabel()}`;


### PR DESCRIPTION
**Issue #70**

**Description of changes**
Adds diagnostics and applies them for scenarios that are duplicated. Note that there also seemed to be a bug with how the ranges for a scenario's text was stored, and so I fixed that. It used to include the whitespace around the scenario.

**Testing**
Tested with the simple project locally on Windows Subsystem for Linux (Ubuntu)

**Declaration**
By submitting this pull request, I confirm that my contribution is made under the terms of the parent repository's license, and requires no attribution or license modification.
